### PR TITLE
feat: upload image for an item & various bugfixes

### DIFF
--- a/src/lib/components/ItemForm.svelte
+++ b/src/lib/components/ItemForm.svelte
@@ -37,7 +37,7 @@ This unfortunately causes us to send the entire Item object to the edit action a
         <!-- TODO: figure out how to display the existing image in case of editing -->
         <div class="form-group col-md-4">
             <label for="image">Image</label>
-            <input type="file" class="form-control" id="image" name="image">
+            <input type="file" class="form-control" id="image" name="image" accept=".jpg, .png, .jpeg">
         </div>
         <div class="form-group col-md-2">
             <label for="size">Size</label>

--- a/src/lib/components/ItemForm.svelte
+++ b/src/lib/components/ItemForm.svelte
@@ -24,15 +24,20 @@
     }
 </script>
 
-<form method="POST" action="{action}" use:enhance>
+<!--
+In case of editing, we pre-populate the existing values of these fields so that the customer knows the value they are about to change.
+This unfortunately causes us to send the entire Item object to the edit action and to the backend API (which supports piecewise updates).
+-->
+<form method="POST" action="{action}" use:enhance enctype="multipart/form-data">
     <div class="form-row">
         <div class="form-group col-md-4">
             <label for="name">Name of the item</label>
             <input type="text" class="form-control" id="name" name="name" value="{getValue('name')}" required>
         </div>
+        <!-- TODO: figure out how to display the existing image in case of editing -->
         <div class="form-group col-md-4">
-            <label for="image">Image URL</label>
-            <input type="text" class="form-control" id="image" name="image" value="{getValue('image')}">
+            <label for="image">Image</label>
+            <input type="file" class="form-control" id="image" name="image">
         </div>
         <div class="form-group col-md-2">
             <label for="size">Size</label>

--- a/src/lib/itemFormUtils.ts
+++ b/src/lib/itemFormUtils.ts
@@ -52,7 +52,7 @@ export function toTitleCase(str: string): string {
 }
 
 export async function uploadImageForItem(item: Item, data: FormData) {
-    var file: File = data.get("image") as File;
+    const file: File = data.get("image") as File;
     await ItemImagesService.itemsPostItemsItemIdImagesPost(item.item_id!, {
         image_file: file
     });

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -8,7 +8,7 @@ export const load = (async ({ cookies }) => {
     OpenAPI.TOKEN = accessToken;
     try {
         const user = await UsersService.usersUserIdGetUserGet();
-        cookies.set(USER_ID, user.user_id);
+        cookies.set(USER_ID, user.user_id!);
         return { user }
     }
     catch (err) {

--- a/src/routes/items/+page.server.ts
+++ b/src/routes/items/+page.server.ts
@@ -1,5 +1,5 @@
-import { type Item, Time, Season, Occasion, ItemsService, type Accessory, type Bottomwear, type Footwear, type Topwear, type SinglePiece, type Underwear } from "../../client";
-import { getItemFormData, getItemFormModel } from "$lib/itemFormUtils";
+import { type Item, Time, Season, Occasion, ItemsService, type Accessory, type Bottomwear, type Footwear, type Topwear, type SinglePiece, type Underwear, ItemImagesService } from "../../client";
+import { getItemFormData, getItemFormModel, uploadImageForItem } from "$lib/itemFormUtils";
 import { fail, redirect } from "@sveltejs/kit";
 import { USER_ID } from "../../constants";
 
@@ -21,13 +21,13 @@ export const actions = {
         if (!userId) {
             throw redirect(302, "/unauthorised");
         }
+        var createdItem = null;
         try {
             var itemToBeCreated: Item = getItemFormData(data, userId);
             try {
-                const createdItem: any = await ItemsService.itemsPostItemsPost(itemToBeCreated);
-                console.log("Successfully created new item: " + createdItem);
-                // TODO below once API is fixed to return createdItem
-                // return redirect(303, "/items/" + createdItem.item_id);
+                createdItem = await ItemsService.itemsPostItemsPost(itemToBeCreated);
+                console.log("Successfully created new item: " + createdItem.item_id);
+                await uploadImageForItem(createdItem, data);
             }
             catch (err) {
                 console.log("Error occured when trying to create item ", err);
@@ -39,5 +39,7 @@ export const actions = {
             // user will simply see the all items page without knowing whether the op was a success
             return fail(422, { failure: true, errorMessage: "Invalid input data! :/" })
         }
+        // this needs to be outside any catch block as per Svelte docs
+        throw redirect(303, "/items/" + createdItem.item_id);
 	}
 };

--- a/src/routes/items/+page.server.ts
+++ b/src/routes/items/+page.server.ts
@@ -21,9 +21,9 @@ export const actions = {
         if (!userId) {
             throw redirect(302, "/unauthorised");
         }
-        var createdItem = null;
+        let createdItem = null;
         try {
-            var itemToBeCreated: Item = getItemFormData(data, userId);
+            const itemToBeCreated: Item = getItemFormData(data, userId);
             try {
                 createdItem = await ItemsService.itemsPostItemsPost(itemToBeCreated);
                 console.log("Successfully created new item: " + createdItem.item_id);

--- a/src/routes/items/[item_id]/+page.server.ts
+++ b/src/routes/items/[item_id]/+page.server.ts
@@ -23,9 +23,9 @@ export const actions = {
             throw redirect(302, "/unauthorised");
         }
         try {
-            var inputItem: Item = getItemFormData(data, userId);
+            const inputItem: Item = getItemFormData(data, userId);
             // the form does not send back the `item_id`
-            var completeItem = {
+            const completeItem = {
                 ...{ "item_id": item.item_id }, ...inputItem
             };
             // TODO: need to find a better way to do this

--- a/src/routes/items/[item_id]/+page.svelte
+++ b/src/routes/items/[item_id]/+page.svelte
@@ -3,8 +3,8 @@
 
     export let data;
     export let form;
-    let item = data.item;
-    $: editMode = false;
+    $: item = data.item;
+    $: editMode = data.editMode;
 
     function turnOnEditMode() {
         editMode = true;

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,7 +1,7 @@
 import { AuthenticationService, type AuthLoginPostRequest, ApiError, UsersService } from "../../client"
 import type { Actions } from "./$types"
 import { fail, redirect } from "@sveltejs/kit";
-import { ACCESS_TOKEN, USER_ID, USER_NAME } from "../../constants";
+import { ACCESS_TOKEN, USER_ID } from "../../constants";
 import { OpenAPI } from "../../client/core/OpenAPI";
 
 export const actions: Actions = {


### PR DESCRIPTION
### Features added:
- Upload an image while creating an item
- Upload an image while editing an item
- There are 2 API calls for updating: 1 for item properties and 1 for uploading image. These APIs are called only when the associated properties are changed.

### Bugs fixed:
- Redirect to the created item was not working because the thrown `Redirect` object was swallowed by the enclosing `catch`
- `editMode` was not getting reset to `false` after item updation because of which the form was getting rendered even after the user had finished updating the item.